### PR TITLE
fix: Modal visibility + DevTools toggle improvements

### DIFF
--- a/packages/ui/src/components/DevtoolsToggle.tsx
+++ b/packages/ui/src/components/DevtoolsToggle.tsx
@@ -12,27 +12,27 @@ const STORAGE_KEY = 'graphix-devtools-visible';
 
 const toggleStyles = css({
   position: 'fixed',
-  bottom: '8px',
+  bottom: '60px',  // Above the TanStack panels
   left: '8px',
   zIndex: 99999,
   display: 'flex',
   alignItems: 'center',
   gap: '6px',
-  padding: '6px 10px',
-  backgroundColor: 'gray.900',
+  padding: '8px 12px',
+  backgroundColor: 'gray.800',
   border: '1px solid',
-  borderColor: 'gray.700',
-  borderRadius: '6px',
-  color: 'gray.400',
-  fontSize: '11px',
+  borderColor: 'gray.600',
+  borderRadius: '8px',
+  color: 'gray.200',
+  fontSize: '12px',
   fontFamily: 'monospace',
   cursor: 'pointer',
   transition: 'all 0.15s',
-  opacity: 0.7,
+  boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
   _hover: {
-    opacity: 1,
-    borderColor: 'gray.600',
-    color: 'gray.200',
+    backgroundColor: 'gray.700',
+    borderColor: 'gray.500',
+    color: 'white',
   },
 });
 

--- a/packages/ui/src/components/chat/ThreadModal.tsx
+++ b/packages/ui/src/components/chat/ThreadModal.tsx
@@ -32,12 +32,15 @@ interface ThreadModalProps {
 
 const overlayStyles = css({
   position: 'fixed',
-  inset: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.7)',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.8)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  zIndex: 1100,
+  zIndex: 10000,  // Very high to ensure it's above everything
   animation: 'fadeIn 0.15s ease',
 });
 
@@ -266,6 +269,11 @@ export function ThreadModal({
   };
 
   if (!isOpen) return null;
+
+  // Guard for SSR/tests where document.body might not exist
+  if (typeof document === 'undefined' || !document.body) {
+    return null;
+  }
 
   // Use portal to render at body level (escapes parent fixed positioning)
   return createPortal(


### PR DESCRIPTION
## Summary

Fixes two UI issues:

### ThreadModal not appearing
- Added SSR guard for `document.body`
- Changed from `inset: 0` to explicit `top/left/right/bottom: 0`
- Increased z-index to 10000 (above all other UI including chat panel)

### DevTools toggle hard to see
- Moved from `bottom: 8px` to `bottom: 60px` (above TanStack panels)
- Removed low opacity (was 0.7)
- Increased padding and font size
- Added box shadow for contrast

## Test Plan
- [x] ThreadModal tests pass (7 tests)
- [ ] Manual: Click clock icon in chat header → modal appears centered
- [ ] Manual: DevTools toggle visible and functional