### PR TITLE
feat: ComfyUI startup integration and status indicator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # GRAPHIX MAKEFILE - Development automation for the Graphix monorepo
 # ============================================================================
 
-.PHONY: help install dev dev-web dev-desktop dev-server build test clean nuke
+.PHONY: help install dev dev-full dev-web dev-desktop dev-server dev-comfyui build test clean nuke
 
 # Colors for pretty output
 CYAN := \033[36m
@@ -21,11 +21,13 @@ help:
 	@echo "$(YELLOW)QUICK START:$(RESET)"
 	@echo "  $(GREEN)make install$(RESET)      - Install all dependencies (first time)"
 	@echo "  $(GREEN)make dev$(RESET)          - Start everything (server + web UI)"
+	@echo "  $(GREEN)make dev-full$(RESET)     - Start everything + comfyui-mcp (for image generation)"
 	@echo "  $(GREEN)make dev-desktop$(RESET)  - Start desktop app (Tauri)"
 	@echo ""
 	@echo "$(YELLOW)INDIVIDUAL SERVICES:$(RESET)"
 	@echo "  $(GREEN)make dev-server$(RESET)   - Start backend server only (port 3002)"
 	@echo "  $(GREEN)make dev-web$(RESET)      - Start web UI only (port 5173)"
+	@echo "  $(GREEN)make dev-comfyui$(RESET)  - Start comfyui-mcp only (port 3001)"
 	@echo ""
 	@echo "$(YELLOW)BUILD & TEST:$(RESET)"
 	@echo "  $(GREEN)make build$(RESET)        - Build all packages"
@@ -89,6 +91,21 @@ dev-desktop: dev-server-bg
 	@echo "$(CYAN)🖥️  Starting Tauri desktop app...$(RESET)"
 	@echo "$(YELLOW)   First build takes ~2 min (downloading Rust crates)$(RESET)"
 	cd packages/ui && bun run tauri:dev
+
+dev-comfyui:
+	@echo "$(CYAN)🎨 Starting comfyui-mcp...$(RESET)"
+	cd ../comfyui-mcp && npm start
+
+dev-comfyui-bg:
+	@echo "$(CYAN)🎨 Starting comfyui-mcp in background...$(RESET)"
+	@cd ../comfyui-mcp && npm start &
+	@sleep 3
+
+dev-full: dev-comfyui-bg dev-server-bg dev-web
+	@echo "$(GREEN)🚀 Full stack running (with image generation)!$(RESET)"
+	@echo "   ComfyUI MCP: http://localhost:3001"
+	@echo "   Server: http://localhost:3002"
+	@echo "   Web UI: http://localhost:5173"
 
 # ============================================================================
 # BUILD
@@ -174,4 +191,5 @@ kill:
 	-pkill -f "bun run dev" 2>/dev/null
 	-pkill -f "vite" 2>/dev/null
 	-pkill -f "graphix" 2>/dev/null
+	-pkill -f "comfyui-mcp" 2>/dev/null
 	@echo "$(GREEN)✅ Processes killed!$(RESET)"

--- a/packages/ui/src/api/hooks/index.ts
+++ b/packages/ui/src/api/hooks/index.ts
@@ -16,3 +16,4 @@ export * from "./useControlNet";
 export * from "./useUploads";
 export * from "./useTextGeneration";
 export * from "./useBeats";
+export * from "./useServiceHealth";

--- a/packages/ui/src/api/hooks/useServiceHealth.ts
+++ b/packages/ui/src/api/hooks/useServiceHealth.ts
@@ -1,0 +1,84 @@
+/**
+ * Service Health Hooks
+ *
+ * Hooks for monitoring backend service health status.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+export interface ComfyUIHealthResponse {
+  status: "connected" | "unreachable" | "error";
+  latency_ms?: number;
+  url: string;
+  hint?: string;
+  error?: string;
+}
+
+export interface ServerHealthResponse {
+  status: "ok";
+  timestamp: string;
+}
+
+/**
+ * Check ComfyUI MCP server connectivity.
+ * Polls every 30 seconds to keep status current.
+ */
+export function useComfyUIHealth(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ["health", "comfyui"],
+    queryFn: async (): Promise<ComfyUIHealthResponse> => {
+      const response = await fetch("/api/health/comfyui");
+      return response.json();
+    },
+    refetchInterval: 30_000, // Poll every 30 seconds
+    retry: false, // Don't retry on failure - just show status
+    enabled: options?.enabled ?? true,
+  });
+}
+
+/**
+ * Check main server health.
+ * Polls every 30 seconds.
+ */
+export function useServerHealth(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ["health", "server"],
+    queryFn: async (): Promise<ServerHealthResponse> => {
+      const response = await fetch("/api/health");
+      if (!response.ok) {
+        throw new Error("Server unreachable");
+      }
+      return response.json();
+    },
+    refetchInterval: 30_000,
+    retry: false,
+    enabled: options?.enabled ?? true,
+  });
+}
+
+/**
+ * Combined service health status.
+ * Returns overall health of all services.
+ */
+export function useServiceHealth() {
+  const server = useServerHealth();
+  const comfyui = useComfyUIHealth({ enabled: server.isSuccess });
+
+  return {
+    server: {
+      status: server.isSuccess ? "ok" : server.isError ? "error" : "loading",
+      isLoading: server.isLoading,
+      isError: server.isError,
+    },
+    comfyui: {
+      status: comfyui.data?.status ?? (comfyui.isLoading ? "loading" : "error"),
+      latency: comfyui.data?.latency_ms,
+      url: comfyui.data?.url,
+      hint: comfyui.data?.hint,
+      isLoading: comfyui.isLoading,
+      isError: comfyui.isError || comfyui.data?.status !== "connected",
+    },
+    isFullyOperational:
+      server.isSuccess && comfyui.data?.status === "connected",
+  };
+}

--- a/packages/ui/src/routes/__root.tsx
+++ b/packages/ui/src/routes/__root.tsx
@@ -7,7 +7,8 @@
 
 import { createRootRoute, Link, Outlet } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import { useServiceHealth } from '../api/hooks';
 
 const DEVTOOLS_STORAGE_KEY = 'graphix-devtools-visible';
 
@@ -19,6 +20,7 @@ function RootLayout() {
     const stored = localStorage.getItem(DEVTOOLS_STORAGE_KEY);
     return stored === null ? true : stored === 'true';
   });
+  const health = useServiceHealth();
 
   // Listen for storage changes (from DevtoolsToggle in main.tsx)
   useEffect(() => {
@@ -208,33 +210,75 @@ function RootLayout() {
           overflow: auto;
         }
         
+        .app-status-group {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+        }
+
         .app-status {
           display: flex;
           align-items: center;
-          gap: 0.5rem;
+          gap: 0.375rem;
           font-size: 0.75rem;
           color: #71717a;
+          cursor: default;
         }
-        
+
         .app-status .status-text {
           display: none;
         }
-        
+
         @media (min-width: 768px) {
           .app-status .status-text {
             display: inline;
           }
         }
-        
+
         .app-status .dot {
           width: 8px;
           height: 8px;
           border-radius: 50%;
           background: #22c55e;
         }
-        
+
         .app-status .dot.offline {
           background: #ef4444;
+        }
+
+        .app-status .dot.loading {
+          background: #f59e0b;
+          animation: pulse 1.5s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+
+        .status-tooltip {
+          position: relative;
+        }
+
+        .status-tooltip::after {
+          content: attr(data-tooltip);
+          position: absolute;
+          bottom: -32px;
+          right: 0;
+          background: #27272a;
+          color: #fafafa;
+          padding: 0.375rem 0.625rem;
+          border-radius: 4px;
+          font-size: 0.6875rem;
+          white-space: nowrap;
+          opacity: 0;
+          pointer-events: none;
+          transition: opacity 0.15s ease;
+          z-index: 50;
+        }
+
+        .status-tooltip:hover::after {
+          opacity: 1;
         }
       `}</style>
       
@@ -294,9 +338,25 @@ function RootLayout() {
           </Link>
         </nav>
         
-        <div className="app-status">
-          <div className="dot" id="server-status"></div>
-          <span className="status-text">Server</span>
+        <div className="app-status-group">
+          <div
+            className="app-status status-tooltip"
+            data-tooltip={health.server.status === 'ok' ? 'Backend connected' : 'Backend offline'}
+          >
+            <div className={`dot ${health.server.status === 'ok' ? '' : health.server.isLoading ? 'loading' : 'offline'}`} />
+            <span className="status-text">Server</span>
+          </div>
+          <div
+            className="app-status status-tooltip"
+            data-tooltip={
+              health.comfyui.status === 'connected'
+                ? `ComfyUI connected (${health.comfyui.latency}ms)`
+                : health.comfyui.hint || 'ComfyUI offline - run: make dev-full'
+            }
+          >
+            <div className={`dot ${health.comfyui.status === 'connected' ? '' : health.comfyui.isLoading ? 'loading' : 'offline'}`} />
+            <span className="status-text">ComfyUI</span>
+          </div>
         </div>
       </header>
       


### PR DESCRIPTION
## Summary
- Add `make dev-full` command to start comfyui-mcp alongside server and UI
- Add `make dev-comfyui` for standalone comfyui-mcp startup  
- Display live connection status indicators in header for Server and ComfyUI
- Show helpful tooltip ("run: make dev-full") when ComfyUI is offline

## Changes
- **Makefile**: New `dev-full`, `dev-comfyui`, `dev-comfyui-bg` targets; updated `kill` target
- **useServiceHealth.ts**: New hook for polling `/health` and `/health/comfyui` endpoints
- **__root.tsx**: Status indicators with color-coded dots and tooltips

## Test plan
- [ ] Run `make dev` - server/UI start, ComfyUI shows offline (red dot)
- [ ] Run `make dev-full` - all three services start, both dots green
- [ ] Hover over ComfyUI indicator - tooltip shows latency when connected
- [ ] Stop comfyui-mcp - indicator turns red within 30s, tooltip shows hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)